### PR TITLE
lighttpd needs `ssl.disable-client-renegotiation = "enable"`

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Requirements:
 - `build-essential` (Perl, GCC, Make)
 - Docker
 
+**Note: None of the listed web servers are vulnerable to CVE-2021-3449 with OpenSSL 1.1.1k or later.**
+
 | Server                                       | Distro       | Version | Demo                 | Result        |
 | -------------------------------------------- | ------------ | ------- | -------------------- | ------------- |
 | [OpenSSL s_server](#openssl-simple-server)   | -            | 1.1.1j  | `make demo-openssl`  | Crash         |
@@ -75,7 +77,7 @@ Requirements:
 | [HAProxy](#haproxy)                          | Ubuntu 20.04 | 2.0.13  | `make demo-haproxy`  | No effect     |
 | [lighttpd](#lighttpd)                        | Ubuntu 18.04 | 1.4.55  | `make demo-lighttpd` | Crash         |
 | [lighttpd](#lighttpd)                        | Ubuntu 20.04 | 1.4.55  | `make demo-lighttpd` | Crash         |
-| [lighttpd](#lighttpd)                        | Ubuntu 21.04 | 1.4.59  | `make demo-lighttpd` | No effect     |
+| [lighttpd](#lighttpd)                        | Ubuntu 21.04 | 1.4.59  | `make demo-lighttpd` | No effect with config option |
 | [NGINX](#nginx)                              | Ubuntu 18.04 | 1.14.0  | `make demo-nginx`    | Partial crash |
 | [NGINX](#nginx)                              | Ubuntu 20.04 | 1.18.0  | `make demo-nginx`    | No effect     |
 | Node.js <=12                                 | Ubuntu 18.04 |         |                      | No effect     |
@@ -205,7 +207,7 @@ malicious handshake failed, exploit might have worked: EOF
 
 ### lighttpd
 
-lighttpd versions 1.4.56 and up are not vulnerable.
+lighttpd versions 1.4.56 and up are not vulnerable if `ssl.disable-client-renegotiation = "enable"` is configured in lighttpd.conf.
 
 lighttpd web server <= 1.4.55 with "intermediate" TLS configuration is vulnerable.
 


### PR DESCRIPTION
@terorie: My apologies.  After testing more carefully with openssl 1.1.1j, I found that lighttpd needs `ssl.disable-client-renegotiation = "enable"` with lighttpd 1.4.56 and later for `SSL_OP_NO_RENEGOTIATION` to be applied at startup.  This was intended to be the default, and will be the default in the upcoming lighttpd 1.4.60.